### PR TITLE
adapt to deprecated jump_to_location

### DIFF
--- a/lua/definition-or-references/definitions.lua
+++ b/lua/definition-or-references/definitions.lua
@@ -33,9 +33,10 @@ local function definitions()
         if util.cursor_not_on_result(current_bufnr, current_cursor, first_definition) then
           methods.clear_references()
           log.trace("definitions", "Current cursor not on result")
-          vim.lsp.util.jump_to_location(
+          vim.lsp.util.show_location(
             first_definition,
-            vim.lsp.get_client_by_id(context.client_id).offset_encoding
+            vim.lsp.get_client_by_id(context.client_id).offset_encoding,
+            { focus = true }
           )
           return
         end

--- a/lua/definition-or-references/references.lua
+++ b/lua/definition-or-references/references.lua
@@ -35,10 +35,10 @@ local function handle_references_response(context)
     then
       vim.notify("No definition but single reference found")
     end
-    vim.lsp.util.jump_to_location(
+    vim.lsp.util.show_document(
       result_entries[1],
       vim.lsp.get_client_by_id(context.client_id).offset_encoding,
-      true
+      { reuse_win = true, focus = true }
     )
 
     return


### PR DESCRIPTION
## 📃 Summary

vim.lsp.util.jump_to_location is deprecated,  [docs](https://neovim.io/doc/user/deprecated.html#vim.lsp.util.jump_to_location)
This replaces it with `vim.lsp.util.show_document` which jump_to_location uses anyways.

## 📸 Preview

<!-- If there's a visual impact to your change, please provide a screenshot. You can directly upload it to GitHub by dragging in this text area. -->
