### PR TITLE
Fix typo and deprecated `vim.lsp.util.make_position_params`

### DIFF
--- a/lua/definition-or-references/definitions.lua
+++ b/lua/definition-or-references/definitions.lua
@@ -33,7 +33,7 @@ local function definitions()
         if util.cursor_not_on_result(current_bufnr, current_cursor, first_definition) then
           methods.clear_references()
           log.trace("definitions", "Current cursor not on result")
-          vim.lsp.util.show_location(
+          vim.lsp.util.show_document(
             first_definition,
             vim.lsp.get_client_by_id(context.client_id).offset_encoding,
             { focus = true }

--- a/lua/definition-or-references/utils.lua
+++ b/lua/definition-or-references/utils.lua
@@ -40,7 +40,8 @@ function M.get_filename_fn()
 end
 
 function M.make_params()
-  local params = vim.lsp.util.make_position_params(0)
+  local clients = vim.lsp.get_clients()
+  local params = vim.lsp.util.make_position_params(0, clients[1].offset_encoding)
 
   params.context = { includeDeclaration = false }
 


### PR DESCRIPTION
## 📃 Summary

Fixed typo from my [last PR
](https://github.com/KostkaBrukowa/definition-or-references.nvim/pull/5)😓

Also updated `vim.lsp.util.make_position_params` to avoid warning about missing encoding, https://github.com/neovim/neovim/pull/31249
## 📸 Preview

<!-- If there's a visual impact to your change, please provide a screenshot. You can directly upload it to GitHub by dragging in this text area. -->
